### PR TITLE
Implementación del punto final: actualización de JWT para usuarios

### DIFF
--- a/schema.yml
+++ b/schema.yml
@@ -106,6 +106,166 @@ paths:
                       try again later.
                   summary: Database connection error
           description: '**(INTERNAL_SERVER_ERROR)** An unexpected error occurred.'
+  /api/v1/user/jwt/refresh/:
+    post:
+      operationId: user_jwt_refresh_create
+      description: |-
+        Handle POST requests for token refresh.
+
+        This method allows refreshing of a user's tokens. It waits for a POST request
+        with the access and refresh tokens, validates the information, and then
+        returns a response with the new tokens if the data is valid or returns an
+        error response if it is not.
+      tags:
+      - Users
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RefreshTokenRequest'
+            examples:
+              DataValid:
+                value:
+                  access: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoiYWNjZXNzIiwiZXhwIjoxNzA2Mjk2MzI3LCJpYXQiOjE3MDYyODkxMjcsImp0aSI6IjQ0Zjg3MDdjZTdhOTQ0Y2RhYWRlNzlhMDg1OThiY2NkIiwidXNlcl9pZCI6IjUwNTI5MjBjLWE3ZDYtNDM4ZS1iZmQwLWVhNTUyMTM4ODM2YyJ9.-FPGYs1m-SDZDs3FJ3wlnqESVhcIg8oYAgKOFBD6Qic
+                  refresh: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTcwNjM3NTUyNywiaWF0IjoxNzA2Mjg5MTI3LCJqdGkiOiI3NzE5OGZmM2JkYWQ0MTk5YTExNjcwZGMwMzdmNTM0YyIsInVzZXJfaWQiOiI1MDUyOTIwYy1hN2Q2LTQzOGUtYmZkMC1lYTU1MjEzODgzNmMifQ.dfHpJRflOA1M2BmraxcW401EJvrTqU6HfbVmHHRkF2U
+                summary: JWT for user
+                description: |-
+                  Valid data for the request. The following validations will be applied:
+                  - **Access token:** must be a valid token and expired.
+                  - **Refresh token:** must be a valid token and not expired.
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/RefreshTokenRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/RefreshTokenRequest'
+        required: true
+      security:
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  access:
+                    type: string
+                  refresh:
+                    type: string
+              examples:
+                ResponseOk:
+                  value:
+                    access: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoiYWNjZXNzIiwiZXhwIjoxNzExMDU0MzYyLCJpYXQiOjE3MTEwNDcxNjIsImp0aSI6IjY0MTE2YzgyYjhmMDQzOWJhNTJkZGZmMzgyNzQ2ZTIwIiwidXNlcl9pZCI6IjJhNmI0NTNiLWZhMmItNDMxOC05YzM1LWIwZTk2ZTg5NGI2MyJ9.gfhWpy5rYY6P3Xrg0usS6j1KhEvF1HqWMiU7AaFkp9A
+                    refresh: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTcxMTEzMzU2MiwiaWF0IjoxNzExMDQ3MTYyLCJqdGkiOiI2ZTRmNTdkMGJjNTc0NWY0OWMzODg4YjQ2YTM1OTJjNSIsInVzZXJfaWQiOiIyYTZiNDUzYi1mYTJiLTQzMTgtOWMzNS1iMGU5NmU4OTRiNjMifQ.81pQ3WftFZs5O50vGqwY2a6yPkXArQK6WKyrwus3s6A
+                  summary: Valid request
+          description: '**(OK)** New user tokens.'
+        '400':
+          content:
+            application/json:
+              schema:
+                properties:
+                  code:
+                    type: string
+                  detail:
+                    type: object
+                    properties:
+                      access:
+                        type: array
+                        items:
+                          type: string
+                      refresh:
+                        type: array
+                        items:
+                          type: string
+              examples:
+                InvalidData1:
+                  value:
+                    code: invalid_request_data
+                    detail:
+                      access:
+                      - Token is not expired.
+                  summary: Access token not expired
+                InvalidData2:
+                  value:
+                    code: invalid_request_data
+                    detail:
+                      refresh:
+                      - Token is expired.
+                  summary: Refresh token expired
+                InvalidData3:
+                  value:
+                    code: invalid_request_data
+                    detail:
+                      access:
+                      - Token is invalid.
+                      refresh:
+                      - Token is invalid.
+                  summary: Invalid tokens
+                InvalidData4:
+                  value:
+                    code: invalid_request_data
+                    detail:
+                      access:
+                      - This field is required.
+                      - This field may not be blank.
+                      - This field may not be null.
+                      refresh:
+                      - This field is required.
+                      - This field may not be blank.
+                      - This field may not be null.
+                  summary: Invalid request data
+          description: '**(BAD_REQUEST)** The request data are invalid, error message(s)
+            are returned for each field that did not pass the validations.'
+        '401':
+          content:
+            application/json:
+              schema:
+                properties:
+                  code:
+                    type: string
+                  detail:
+                    type: string or object
+              examples:
+                UserNotFound:
+                  value:
+                    code: user_not_found
+                    detail: User 2a6b453b-fa2b-4318-9c35-b0e96e894b63 not found.
+                  summary: The user of the tokens was not found
+                TokenNotFound:
+                  value:
+                    code: token_not_found
+                    detail: Tokens do not exist.
+                  summary: The tokens were not foun
+                TokenError:
+                  value:
+                    code: token_error
+                    detail:
+                      message: The token does not match the user's last tokens.
+                      token_type: Access
+                      token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTcxMTEzMzU2MiwiaWF0IjoxNzExMDQ3MTYyLCJqdGkiOiI2ZTRmNTdkMGJjNTc0NWY0OWMzODg4YjQ2YTM1OTJjNSIsInVzZXJfaWQiOiIyYTZiNDUzYi1mYTJiLTQzMTgtOWMzNS1iMGU5NmU4OTRiNjMifQ.81pQ3WftFZs5O50vGqwY2a6yPkXArQK6WKyrwus3s6A
+                  summary: The tokens do not match the user's last tokens
+          description: |-
+            **(UNAUTHORIZED)** Tokens cannot be refreshed, this is due to one of the following reasons.
+            - The user of the tokens was not found.
+            - The tokens do not match the user's last tokens.
+            - The tokens were not found.
+        '500':
+          content:
+            application/json:
+              schema:
+                properties:
+                  detail:
+                    type: string
+                  code:
+                    type: string
+              examples:
+                DatabaseConnectionError:
+                  value:
+                    code: database_connection_error
+                    detail: Unable to establish a connection with the database. Please
+                      try again later.
+                  summary: Database connection error
+          description: '**(INTERNAL_SERVER_ERROR)** An unexpected error occurred.'
   /api/v1/user/login/:
     post:
       operationId: user_login_create
@@ -253,6 +413,21 @@ components:
       required:
       - email
       - password
+    RefreshTokenRequest:
+      type: object
+      description: |-
+        Handles the data for user token refresh. Checks that the provided access and
+        refresh tokens meet the necessary requirements.
+      properties:
+        refresh:
+          type: string
+          minLength: 1
+        access:
+          type: string
+          minLength: 1
+      required:
+      - access
+      - refresh
     RegisterRequest:
       type: object
       description: |-

--- a/src/apps/exceptions.py
+++ b/src/apps/exceptions.py
@@ -107,3 +107,21 @@ class JWTNotFound(DetailDictMixin, APIException):
             self.detail = detail or self.default_detail
         self.code = code or self.default_code
         super().__init__(detail=self.detail, code=self.code)
+
+
+class JWTError(DetailDictMixin, APIException):
+    """
+    Exception raised when a token error occurs.
+    """
+
+    status_code = status.HTTP_401_UNAUTHORIZED
+    default_detail = "Token error."
+    default_code = "token_error"
+
+    def __init__(self, detail: str | Dict[str, Any] = None, code: str = None):
+        if isinstance(detail, dict):
+            self.detail = {"detail": detail or self.default_detail}
+        else:
+            self.detail = detail or self.default_detail
+        self.code = code or self.default_code
+        super().__init__(detail=self.detail, code=self.code)

--- a/src/apps/exceptions.py
+++ b/src/apps/exceptions.py
@@ -91,7 +91,7 @@ class UserInactiveError(DetailDictMixin, APIException):
         super().__init__(detail=self.detail, code=self.code)
 
 
-class JWTNotFound(DetailDictMixin, APIException):
+class JWTNotFoundError(DetailDictMixin, APIException):
     """
     Exception raised when a token is not found.
     """

--- a/src/apps/users/applications/__init__.py
+++ b/src/apps/users/applications/__init__.py
@@ -1,2 +1,3 @@
 from .register import Registration
 from .authentication import Authentication
+from .refresh_tokens import RefreshTokens

--- a/src/apps/users/applications/refresh_tokens.py
+++ b/src/apps/users/applications/refresh_tokens.py
@@ -1,0 +1,54 @@
+from typing import Dict, Any
+
+from apps.users.applications.use_case import JWTUseCaseBase
+from apps.users.domain.abstractions import (
+    IJWTRepository,
+    IUserRepository,
+    ITokenClass,
+)
+from apps.users.domain.typing import JWTType
+
+
+class RefreshTokens(JWTUseCaseBase):
+    """
+    Use case that is responsible for refreshing the user tokens.
+
+    This class is responsible for managing the process of refreshing the user tokens.
+    Interacts with `JwtRepository`, `UserRepository` and `ITokenClass`, these
+    dependencies are injected at the point of use.
+
+    Attributes:
+    - jwt_class: An instance of a class implementing the `ITokenClass` interface.
+    - jwt_repository: An instance of a class implementing the `IJwtRepository`
+    interface.
+    - user_repository: An instance of a class implementing the `IUserRepository`
+    interface.
+    """
+
+    def __init__(
+        self,
+        jwt_class: ITokenClass,
+        jwt_repository: IJWTRepository,
+        user_repository: IUserRepository,
+    ) -> None:
+        super().__init__(jwt_repository=jwt_repository, jwt_class=jwt_class)
+        self.user_repository = user_repository
+
+    def refresh_tokens(
+        self, access_data: Dict[str, Any], refresh_data: Dict[str, Any]
+    ) -> Dict[str, JWTType]:
+        """
+        Creates new tokens for the user.
+        """
+
+        user = self.user_repository.get_user(
+            id=access_data["payload"]["user_id"]
+        )
+        tokens = self._verify_latest_tokens(
+            tokens_data={"access": access_data, "refresh": refresh_data},
+            user=user,
+        )
+        self._add_tokens_to_blacklist(tokens=tokens)
+        refresh, access = self._generate_tokens(user=user)
+
+        return {"access": access, "refresh": refresh}

--- a/src/apps/users/applications/refresh_tokens.py
+++ b/src/apps/users/applications/refresh_tokens.py
@@ -7,6 +7,7 @@ from apps.users.domain.abstractions import (
     ITokenClass,
 )
 from apps.users.domain.typing import JWTType
+from apps.users.utils import decode_jwt
 
 
 class RefreshTokens(JWTUseCaseBase):
@@ -50,5 +51,12 @@ class RefreshTokens(JWTUseCaseBase):
         )
         self._add_tokens_to_blacklist(tokens=tokens)
         refresh, access = self._generate_tokens(user=user)
+        self._add_tokens_to_checklist(
+            user=user,
+            token_data=[
+                {"token": refresh, "payload": decode_jwt(token=refresh)},
+                {"token": access, "payload": decode_jwt(token=access)},
+            ],
+        )
 
         return {"access": access, "refresh": refresh}

--- a/src/apps/users/applications/use_case.py
+++ b/src/apps/users/applications/use_case.py
@@ -1,0 +1,61 @@
+from typing import List, Dict, Tuple, Any
+
+from apps.users.domain.abstractions import IJWTRepository, ITokenClass
+from apps.users.domain.typing import AccessToken, RefreshToken
+from apps.users.models import User, JWT
+from apps.exceptions import JWTError, JWTNotFound
+
+
+class JWTUseCaseBase:
+
+    def __init__(
+        self, jwt_repository: IJWTRepository, jwt_class: ITokenClass
+    ) -> None:
+        self.jwt_repository = jwt_repository
+        self.jwt_class = jwt_class
+
+    def _verify_latest_tokens(
+        self, tokens_data: Dict[str, Any], user: User
+    ) -> List[JWT]:
+        """
+        Checks if the tokens provided are the last generated tokens of the user.
+        """
+
+        latest_tokens = self.jwt_repository.get_tokens_user(user=user)[:2]
+        if len(latest_tokens) == 0:
+            raise JWTNotFound(
+                code="token_not_found", detail="Tokens do not exist."
+            )
+        latest_token_jtis = [token_obj.jti for token_obj in latest_tokens]
+        for token in [tokens_data["access"], tokens_data["refresh"]]:
+            if not token["payload"]["jti"] in latest_token_jtis:
+                raise JWTError(
+                    code="token_error",
+                    detail={
+                        "message": "The token does not match the user's last tokens.",
+                        "token_type": token["payload"]["token_type"],
+                        "token": token["token"],
+                    },
+                )
+
+        return latest_tokens
+
+    def _generate_tokens(self, user: User) -> Tuple[RefreshToken, AccessToken]:
+        refresh = self.jwt_class.get_token(user=user)
+        access = refresh.access_token
+
+        return str(refresh), str(access)
+
+    def _add_tokens_to_checklist(
+        self, user: User, token_data: List[Dict[str, Any]]
+    ) -> None:
+        for element in token_data:
+            self.jwt_repository.add_to_checklist(
+                token=element["token"],
+                payload=element["payload"],
+                user=user,
+            )
+
+    def _add_tokens_to_blacklist(self, tokens: List[JWT]) -> None:
+        for token in tokens:
+            self.jwt_repository.add_to_blacklist(token=token)

--- a/src/apps/users/applications/use_case.py
+++ b/src/apps/users/applications/use_case.py
@@ -3,7 +3,7 @@ from typing import List, Dict, Tuple, Any
 from apps.users.domain.abstractions import IJWTRepository, ITokenClass
 from apps.users.domain.typing import AccessToken, RefreshToken
 from apps.users.models import User, JWT
-from apps.exceptions import JWTError, JWTNotFound
+from apps.exceptions import JWTError, JWTNotFoundError
 
 
 class JWTUseCaseBase:
@@ -23,7 +23,7 @@ class JWTUseCaseBase:
 
         latest_tokens = self.jwt_repository.get_tokens_user(user=user)[:2]
         if len(latest_tokens) == 0:
-            raise JWTNotFound(
+            raise JWTNotFoundError(
                 code="token_not_found", detail="Tokens do not exist."
             )
         latest_token_jtis = [token_obj.jti for token_obj in latest_tokens]

--- a/src/apps/users/applications/use_case.py
+++ b/src/apps/users/applications/use_case.py
@@ -7,6 +7,12 @@ from apps.exceptions import JWTError, JWTNotFoundError
 
 
 class JWTUseCaseBase:
+    """
+    Base class for JWT use cases.
+
+    This class provides common methods for handling JWT tokens, such as verifying,
+    generating, and adding tokens to the checklist or blacklist.
+    """
 
     def __init__(
         self, jwt_repository: IJWTRepository, jwt_class: ITokenClass

--- a/src/apps/users/domain/abstractions.py
+++ b/src/apps/users/domain/abstractions.py
@@ -1,7 +1,8 @@
+from rest_framework_simplejwt.tokens import Token
 from django.db.models import QuerySet
 
 from abc import abstractclassmethod, ABC
-from typing import Dict, Any
+from typing import Dict, Any, Protocol
 
 from apps.users.models import User, JWT, JWTBlacklisted
 from .typing import JWTType, JWTPayload
@@ -86,7 +87,7 @@ class IJWTRepository(ABC):
         pass
 
     @abstractclassmethod
-    def add_to_blacklist(cls, token: JWTType) -> None:
+    def add_to_blacklist(cls, token: JWT) -> None:
         """
         Add a token to the blacklist.
 
@@ -95,3 +96,20 @@ class IJWTRepository(ABC):
         """
 
         pass
+
+
+class ITokenClass(Protocol):
+    """
+    Interface that defines the methods that a class must implement to be used as a
+    JWT class.
+    """
+
+    def get_token(self, user: User) -> Token:
+        """
+        This method should return a JWT token for the given user.
+
+        Parameters:
+        - user: The user for which to generate the token.
+        """
+
+        ...

--- a/src/apps/users/infrastructure/db/jwt_repository.py
+++ b/src/apps/users/infrastructure/db/jwt_repository.py
@@ -5,7 +5,7 @@ from django.db import OperationalError
 from apps.users.domain.abstractions import IJWTRepository
 from apps.users.domain.typing import JWTPayload, JWTType
 from apps.users.models import User, JWT, JWTBlacklisted
-from apps.exceptions import JWTNotFound, DatabaseConnectionError
+from apps.exceptions import JWTNotFoundError, DatabaseConnectionError
 
 
 class JWTRepository(IJWTRepository):
@@ -42,7 +42,7 @@ class JWTRepository(IJWTRepository):
             # suddenly unavailable.
             raise DatabaseConnectionError()
         if not token:
-            raise JWTNotFound(
+            raise JWTNotFoundError(
                 code="token_not_found",
                 detail=f'Token {filters.get("token", "")} not found.',
             )

--- a/src/apps/users/infrastructure/serializers/__init__.py
+++ b/src/apps/users/infrastructure/serializers/__init__.py
@@ -1,2 +1,3 @@
 from .register import RegisterSerializer
 from .authentication import AuthenticationSerializer
+from .refresh_token import RefreshTokenSerializer

--- a/src/apps/users/infrastructure/serializers/refresh_token.py
+++ b/src/apps/users/infrastructure/serializers/refresh_token.py
@@ -1,0 +1,48 @@
+from rest_framework import serializers
+from jwt import DecodeError, ExpiredSignatureError
+
+from apps.users.utils import decode_jwt
+
+
+class RefreshTokenSerializer(serializers.Serializer):
+    """
+    Serializer for the refresh token of users in the real estate management system.
+
+    This serializer validates the refresh and access tokens. The refresh token is validated to check if it is expired or not. The access token is validated to check if it is invalid.
+    """
+
+    refresh = serializers.CharField(required=True)
+    access = serializers.CharField(required=True)
+
+    def validate_access(self, value):
+        try:
+            decode_jwt(token=value)
+        except ExpiredSignatureError:
+            payload = decode_jwt(token=value, options={"verify_exp": False})
+            return {
+                "token": value,
+                "payload": payload,
+            }
+        except DecodeError:
+            raise serializers.ValidationError(
+                detail="Token is invalid.", code="token_error"
+            )
+        raise serializers.ValidationError(
+            detail="Token is not expired.", code="token_error"
+        )
+
+    def validate_refresh(self, value):
+        try:
+            payload = decode_jwt(token=value)
+        except ExpiredSignatureError:
+            raise serializers.ValidationError(
+                detail="Token is expired.", code="token_error"
+            )
+        except DecodeError:
+            raise serializers.ValidationError(
+                detail="Token is invalid.", code="token_error"
+            )
+        return {
+            "token": value,
+            "payload": payload,
+        }

--- a/src/apps/users/infrastructure/serializers/refresh_token.py
+++ b/src/apps/users/infrastructure/serializers/refresh_token.py
@@ -1,14 +1,15 @@
 from rest_framework import serializers
 from jwt import DecodeError, ExpiredSignatureError
 
+from apps.users.schemas.refresh_tokens import SerializerSchema
 from apps.users.utils import decode_jwt
 
 
+@SerializerSchema
 class RefreshTokenSerializer(serializers.Serializer):
     """
-    Serializer for the refresh token of users in the real estate management system.
-
-    This serializer validates the refresh and access tokens. The refresh token is validated to check if it is expired or not. The access token is validated to check if it is invalid.
+    Handles the data for user token refresh. Checks that the provided access and
+    refresh tokens meet the necessary requirements.
     """
 
     refresh = serializers.CharField(required=True)

--- a/src/apps/users/infrastructure/urls.py
+++ b/src/apps/users/infrastructure/urls.py
@@ -1,5 +1,5 @@
 from django.urls import path
-from .views import RegisterAPIView, AuthenticationAPIView
+from .views import RegisterAPIView, AuthenticationAPIView, RefreshTokenAPIView
 
 
 urlpatterns = [
@@ -8,5 +8,10 @@ urlpatterns = [
         route="user/login/",
         view=AuthenticationAPIView.as_view(),
         name="authenticate_user",
+    ),
+    path(
+        route="user/jwt/refresh/",
+        view=RefreshTokenAPIView.as_view(),
+        name="refresh_token",
     ),
 ]

--- a/src/apps/users/infrastructure/views/__init__.py
+++ b/src/apps/users/infrastructure/views/__init__.py
@@ -1,2 +1,3 @@
 from .register import RegisterAPIView
 from .authentication import AuthenticationAPIView
+from .refresh_token import RefreshTokenAPIView

--- a/src/apps/users/infrastructure/views/refresh_token.py
+++ b/src/apps/users/infrastructure/views/refresh_token.py
@@ -9,9 +9,16 @@ from typing import Dict, Any
 from apps.users.infrastructure.serializers import RefreshTokenSerializer
 from apps.users.infrastructure.db import JWTRepository, UserRepository
 from apps.users.applications import RefreshTokens
+from apps.users.schemas.refresh_tokens import ViewSchema
 
 
 class RefreshTokenAPIView(generics.GenericAPIView):
+    """
+    API View for refreshing user tokens.
+
+    This view handles the `POST` request to refresh a user's access and refresh tokens
+    in the system.
+    """
 
     authentication_classes = ()
     serializer_class = RefreshTokenSerializer
@@ -45,7 +52,17 @@ class RefreshTokenAPIView(generics.GenericAPIView):
             content_type="application/json",
         )
 
+    @ViewSchema
     def post(self, request: Request, *args, **kwargs) -> Response:
+        """
+        Handle POST requests for token refresh.
+
+        This method allows refreshing of a user's tokens. It waits for a POST request
+        with the access and refresh tokens, validates the information, and then
+        returns a response with the new tokens if the data is valid or returns an
+        error response if it is not.
+        """
+
         serializer = self.serializer_class(data=request.data)
         if serializer.is_valid():
             return self._handle_valid_request(

--- a/src/apps/users/infrastructure/views/refresh_token.py
+++ b/src/apps/users/infrastructure/views/refresh_token.py
@@ -1,0 +1,55 @@
+from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
+from rest_framework.response import Response
+from rest_framework.request import Request
+from rest_framework.serializers import Serializer
+from rest_framework import status, generics
+
+from typing import Dict, Any
+
+from apps.users.infrastructure.serializers import RefreshTokenSerializer
+from apps.users.infrastructure.db import JWTRepository, UserRepository
+from apps.users.applications import RefreshTokens
+
+
+class RefreshTokenAPIView(generics.GenericAPIView):
+
+    authentication_classes = ()
+    serializer_class = RefreshTokenSerializer
+    application_class = RefreshTokens
+
+    def _handle_valid_request(self, token_data: Dict[str, Any]) -> Response:
+
+        tokens = self.application_class(
+            jwt_class=TokenObtainPairSerializer,
+            jwt_repository=JWTRepository,
+            user_repository=UserRepository,
+        ).refresh_tokens(
+            access_data=token_data["access"],
+            refresh_data=token_data["refresh"],
+        )
+
+        return Response(
+            data=tokens,
+            status=status.HTTP_200_OK,
+            content_type="application/json",
+        )
+
+    def _handle_invalid_request(self, serializer: Serializer) -> Response:
+
+        return Response(
+            data={
+                "code": "jwt_error",
+                "detail": serializer.errors,
+            },
+            status=status.HTTP_401_UNAUTHORIZED,
+            content_type="application/json",
+        )
+
+    def post(self, request: Request, *args, **kwargs) -> Response:
+        serializer = self.serializer_class(data=request.data)
+        if serializer.is_valid():
+            return self._handle_valid_request(
+                token_data=serializer.validated_data
+            )
+
+        return self._handle_invalid_request(serializer=serializer)

--- a/src/apps/users/schemas/refresh_tokens.py
+++ b/src/apps/users/schemas/refresh_tokens.py
@@ -1,0 +1,183 @@
+from drf_spectacular.utils import (
+    extend_schema_serializer,
+    extend_schema,
+    OpenApiResponse,
+    OpenApiExample,
+)
+
+
+ViewSchema = extend_schema(
+    tags=["Users"],
+    responses={
+        200: OpenApiResponse(
+            description="**(OK)** New user tokens.",
+            response={
+                "properties": {
+                    "access": {"type": "string"},
+                    "refresh": {"type": "string"},
+                }
+            },
+            examples=[
+                OpenApiExample(
+                    name="response_ok",
+                    summary="Valid request",
+                    value={
+                        "access": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoiYWNjZXNzIiwiZXhwIjoxNzExMDU0MzYyLCJpYXQiOjE3MTEwNDcxNjIsImp0aSI6IjY0MTE2YzgyYjhmMDQzOWJhNTJkZGZmMzgyNzQ2ZTIwIiwidXNlcl9pZCI6IjJhNmI0NTNiLWZhMmItNDMxOC05YzM1LWIwZTk2ZTg5NGI2MyJ9.gfhWpy5rYY6P3Xrg0usS6j1KhEvF1HqWMiU7AaFkp9A",
+                        "refresh": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTcxMTEzMzU2MiwiaWF0IjoxNzExMDQ3MTYyLCJqdGkiOiI2ZTRmNTdkMGJjNTc0NWY0OWMzODg4YjQ2YTM1OTJjNSIsInVzZXJfaWQiOiIyYTZiNDUzYi1mYTJiLTQzMTgtOWMzNS1iMGU5NmU4OTRiNjMifQ.81pQ3WftFZs5O50vGqwY2a6yPkXArQK6WKyrwus3s6A",
+                    },
+                ),
+            ],
+        ),
+        400: OpenApiResponse(
+            description="**(BAD_REQUEST)** The request data are invalid, error message(s) are returned for each field that did not pass the validations.",
+            response={
+                "properties": {
+                    "code": {"type": "string"},
+                    "detail": {
+                        "type": "object",
+                        "properties": {
+                            "access": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                            },
+                            "refresh": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                            },
+                        },
+                    },
+                }
+            },
+            examples=[
+                OpenApiExample(
+                    name="invalid_data1",
+                    summary="Access token not expired",
+                    value={
+                        "code": "invalid_request_data",
+                        "detail": {
+                            "access": ["Token is not expired."],
+                        },
+                    },
+                ),
+                OpenApiExample(
+                    name="invalid_data2",
+                    summary="Refresh token expired",
+                    value={
+                        "code": "invalid_request_data",
+                        "detail": {
+                            "refresh": ["Token is expired."],
+                        },
+                    },
+                ),
+                OpenApiExample(
+                    name="invalid_data3",
+                    summary="Invalid tokens",
+                    value={
+                        "code": "invalid_request_data",
+                        "detail": {
+                            "access": ["Token is invalid."],
+                            "refresh": ["Token is invalid."],
+                        },
+                    },
+                ),
+                OpenApiExample(
+                    name="invalid_data4",
+                    summary="Invalid request data",
+                    value={
+                        "code": "invalid_request_data",
+                        "detail": {
+                            "access": [
+                                "This field is required.",
+                                "This field may not be blank.",
+                                "This field may not be null.",
+                            ],
+                            "refresh": [
+                                "This field is required.",
+                                "This field may not be blank.",
+                                "This field may not be null.",
+                            ],
+                        },
+                    },
+                ),
+            ],
+        ),
+        401: OpenApiResponse(
+            description="**(UNAUTHORIZED)** Tokens cannot be refreshed, this is due to one of the following reasons.\n- The user of the tokens was not found.\n- The tokens do not match the user's last tokens.\n- The tokens were not found.",
+            response={
+                "properties": {
+                    "code": {"type": "string"},
+                    "detail": {"type": "string or object"},
+                }
+            },
+            examples=[
+                OpenApiExample(
+                    name="user_not_found",
+                    summary="The user of the tokens was not found",
+                    value={
+                        "code": "user_not_found",
+                        "detail": "User 2a6b453b-fa2b-4318-9c35-b0e96e894b63 not found.",
+                    },
+                ),
+                OpenApiExample(
+                    name="token_not_found",
+                    summary="The tokens were not foun",
+                    value={
+                        "code": "token_not_found",
+                        "detail": "Tokens do not exist.",
+                    },
+                ),
+                OpenApiExample(
+                    name="token_error",
+                    summary="The tokens do not match the user's last tokens",
+                    value={
+                        "code": "token_error",
+                        "detail": {
+                            "message": "The token does not match the user's last tokens.",
+                            "token_type": "Access",
+                            "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTcxMTEzMzU2MiwiaWF0IjoxNzExMDQ3MTYyLCJqdGkiOiI2ZTRmNTdkMGJjNTc0NWY0OWMzODg4YjQ2YTM1OTJjNSIsInVzZXJfaWQiOiIyYTZiNDUzYi1mYTJiLTQzMTgtOWMzNS1iMGU5NmU4OTRiNjMifQ.81pQ3WftFZs5O50vGqwY2a6yPkXArQK6WKyrwus3s6A",
+                        },
+                    },
+                ),
+            ],
+        ),
+        500: OpenApiResponse(
+            description="**(INTERNAL_SERVER_ERROR)** An unexpected error occurred.",
+            response={
+                "properties": {
+                    "detail": {
+                        "type": "string",
+                    },
+                    "code": {
+                        "type": "string",
+                    },
+                }
+            },
+            examples=[
+                OpenApiExample(
+                    name="database_connection_error",
+                    summary="Database connection error",
+                    value={
+                        "code": "database_connection_error",
+                        "detail": "Unable to establish a connection with the database. Please try again later.",
+                    },
+                ),
+            ],
+        ),
+    },
+)
+
+
+SerializerSchema = extend_schema_serializer(
+    examples=[
+        OpenApiExample(
+            name="data_valid",
+            summary="JWT for user",
+            description="Valid data for the request. The following validations will be applied:\n- **Access token:** must be a valid token and expired.\n- **Refresh token:** must be a valid token and not expired.",
+            value={
+                "access": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoiYWNjZXNzIiwiZXhwIjoxNzA2Mjk2MzI3LCJpYXQiOjE3MDYyODkxMjcsImp0aSI6IjQ0Zjg3MDdjZTdhOTQ0Y2RhYWRlNzlhMDg1OThiY2NkIiwidXNlcl9pZCI6IjUwNTI5MjBjLWE3ZDYtNDM4ZS1iZmQwLWVhNTUyMTM4ODM2YyJ9.-FPGYs1m-SDZDs3FJ3wlnqESVhcIg8oYAgKOFBD6Qic",
+                "refresh": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTcwNjM3NTUyNywiaWF0IjoxNzA2Mjg5MTI3LCJqdGkiOiI3NzE5OGZmM2JkYWQ0MTk5YTExNjcwZGMwMzdmNTM0YyIsInVzZXJfaWQiOiI1MDUyOTIwYy1hN2Q2LTQzOGUtYmZkMC1lYTU1MjEzODgzNmMifQ.dfHpJRflOA1M2BmraxcW401EJvrTqU6HfbVmHHRkF2U",
+            },
+            request_only=True,
+        ),
+    ],
+)

--- a/src/settings/environments/base.py
+++ b/src/settings/environments/base.py
@@ -183,7 +183,7 @@ SPECTACULAR_SETTINGS = {
         },
     ],
     "SERVE_INCLUDE_SCHEMA": False,
-    "SERVE_PERMISSIONS": ["rest_framework.permissions.IsAuthenticated"],
+    # "SERVE_PERMISSIONS": ["rest_framework.permissions.IsAuthenticated"],
     "COMPONENT_SPLIT_REQUEST": True,
     "LICENSE": {
         "name": "MIT License",

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -2,7 +2,11 @@ import pytest
 
 from unittest.mock import Mock
 
-from apps.users.domain.abstractions import IUserRepository, IJWTRepository
+from apps.users.domain.abstractions import (
+    IUserRepository,
+    IJWTRepository,
+    ITokenClass,
+)
 
 
 @pytest.fixture
@@ -21,3 +25,12 @@ def jwt_repository() -> Mock:
     """
 
     return Mock(spec_set=IJWTRepository, name="JWTRepositoryMock")
+
+
+@pytest.fixture
+def jwt_class() -> Mock:
+    """
+    Mock the `TokenClass` class.
+    """
+
+    return Mock(spec_set=ITokenClass, name="TokenClassMock")

--- a/src/tests/users/applications/test_refresh_tokens.py
+++ b/src/tests/users/applications/test_refresh_tokens.py
@@ -1,0 +1,222 @@
+from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
+import pytest
+
+from unittest.mock import Mock
+from typing import Tuple
+
+from apps.users.applications import RefreshTokens
+from apps.exceptions import (
+    DatabaseConnectionError,
+    UserNotFoundError,
+    JWTNotFoundError,
+    JWTError,
+)
+from tests.users.factory import JWTModelFactory, UserModelFactory, JWTFactory
+
+
+@pytest.fixture
+def setUp(user_repository, jwt_repository) -> Tuple[Mock, ...]:
+
+    return user_repository, jwt_repository, TokenObtainPairSerializer
+
+
+class TestApplication:
+    """
+    A test class for the RefreshTokens application.
+
+    This class contains test methods to verify the behavior of the RefreshTokens
+    application. It tests various scenarios such as successful refresh, error
+    handling, and exception cases.
+    """
+
+    application_class = RefreshTokens
+
+    def test_refresh_successfully(self, setUp: Tuple[Mock, ...]) -> None:
+
+        user_repository, jwt_repository, jwt_class = setUp
+        user = UserModelFactory.build()
+        access = JWTFactory.access(user=user)
+        refresh = JWTFactory.refresh(user=user)
+
+        # Building the objects
+        access_obj = JWTModelFactory.build(
+            user=user, jti=access["payload"]["jti"], token=access["token"]
+        )
+        refresh_obj = JWTModelFactory.build(
+            user=user, jti=refresh["payload"]["jti"], token=refresh["token"]
+        )
+
+        # Mocking the methods
+        get_user: Mock = user_repository.get_user
+        get_tokens_user: Mock = jwt_repository.get_tokens_user
+        add_to_blacklist: Mock = jwt_repository.add_to_blacklist
+
+        # Setting the return values
+        get_user.return_value = user
+        get_tokens_user.return_value = [refresh_obj, access_obj]
+
+        _ = self.application_class(
+            user_repository=user_repository,
+            jwt_repository=jwt_repository,
+            jwt_class=jwt_class,
+        ).refresh_tokens(access_data=access, refresh_data=refresh)
+
+        get_user.assert_called_once_with(id=user.id)
+        get_tokens_user.assert_called_once_with(user=user)
+        add_to_blacklist.assert_any_call(token=access_obj)
+        add_to_blacklist.assert_any_call(token=refresh_obj)
+
+    def test_raises_error_getting_user(self, setUp: Tuple[Mock, ...]) -> None:
+
+        user_repository, jwt_repository, jwt_class = setUp
+        user = UserModelFactory.build()
+        access = JWTFactory.access(user=user)
+        refresh = JWTFactory.refresh(user=user)
+
+        # Mocking the methods
+        get_user: Mock = user_repository.get_user
+        get_tokens_user: Mock = jwt_repository.get_tokens_user
+        add_to_blacklist: Mock = jwt_repository.add_to_blacklist
+
+        exceptions = [UserNotFoundError, DatabaseConnectionError]
+        for exception in exceptions:
+            get_user.side_effect = exception
+            with pytest.raises(exception):
+                self.application_class(
+                    user_repository=user_repository,
+                    jwt_repository=jwt_repository,
+                    jwt_class=jwt_class,
+                ).refresh_tokens(access_data=access, refresh_data=refresh)
+
+            get_user.assert_any_call(id=user.id)
+            get_tokens_user.assert_not_called()
+            add_to_blacklist.assert_not_called()
+
+    def test_raises_error_getting_tokens(
+        self, setUp: Tuple[Mock, ...]
+    ) -> None:
+
+        user_repository, jwt_repository, jwt_class = setUp
+        user = UserModelFactory.build()
+        access = JWTFactory.access(user=user)
+        refresh = JWTFactory.refresh(user=user)
+
+        # Mocking the methods
+        get_user: Mock = user_repository.get_user
+        get_tokens_user: Mock = jwt_repository.get_tokens_user
+        add_to_blacklist: Mock = jwt_repository.add_to_blacklist
+
+        # Setting the return values
+        get_user.return_value = user
+        get_tokens_user.side_effect = DatabaseConnectionError
+
+        with pytest.raises(DatabaseConnectionError):
+            self.application_class(
+                user_repository=user_repository,
+                jwt_repository=jwt_repository,
+                jwt_class=jwt_class,
+            ).refresh_tokens(access_data=access, refresh_data=refresh)
+
+        get_user.assert_called_once_with(id=user.id)
+        get_tokens_user.assert_called_once_with(user=user)
+        add_to_blacklist.assert_not_called()
+
+    def test_jwt_not_found(self, setUp: Tuple[Mock, ...]) -> None:
+
+        user_repository, jwt_repository, jwt_class = setUp
+        user = UserModelFactory.build()
+        access = JWTFactory.access(user=user)
+        refresh = JWTFactory.refresh(user=user)
+
+        # Mocking the methods
+        get_user: Mock = user_repository.get_user
+        get_tokens_user: Mock = jwt_repository.get_tokens_user
+        add_to_blacklist: Mock = jwt_repository.add_to_blacklist
+
+        # Setting the return values
+        get_user.return_value = user
+        get_tokens_user.return_value = []
+
+        with pytest.raises(JWTNotFoundError):
+            self.application_class(
+                user_repository=user_repository,
+                jwt_repository=jwt_repository,
+                jwt_class=jwt_class,
+            ).refresh_tokens(access_data=access, refresh_data=refresh)
+
+        get_user.assert_called_once_with(id=user.id)
+        get_tokens_user.assert_called_once_with(user=user)
+        add_to_blacklist.assert_not_called()
+
+    def test_jwt_not_matching(self, setUp: Tuple[Mock, ...]) -> None:
+
+        user_repository, jwt_repository, jwt_class = setUp
+        user = UserModelFactory.build()
+        access = JWTFactory.access(user=user)
+        refresh = JWTFactory.refresh(user=user)
+
+        # Building the objects
+        access_obj = JWTModelFactory.build(
+            user=user, jti="123", token=access["token"]
+        )
+        refresh_obj = JWTModelFactory.build(
+            user=user, jti="456", token=refresh["token"]
+        )
+
+        # Mocking the methods
+        get_user: Mock = user_repository.get_user
+        get_tokens_user: Mock = jwt_repository.get_tokens_user
+        add_to_blacklist: Mock = jwt_repository.add_to_blacklist
+
+        # Setting the return values
+        get_user.return_value = user
+        get_tokens_user.return_value = [refresh_obj, access_obj]
+
+        with pytest.raises(JWTError):
+            self.application_class(
+                user_repository=user_repository,
+                jwt_repository=jwt_repository,
+                jwt_class=jwt_class,
+            ).refresh_tokens(access_data=access, refresh_data=refresh)
+
+        get_user.assert_called_once_with(id=user.id)
+        get_tokens_user.assert_called_once_with(user=user)
+        add_to_blacklist.assert_not_called()
+
+    def test_jwt_error_adding_to_blacklist(
+        self, setUp: Tuple[Mock, ...]
+    ) -> None:
+
+        user_repository, jwt_repository, jwt_class = setUp
+        user = UserModelFactory.build()
+        access = JWTFactory.access(user=user)
+        refresh = JWTFactory.refresh(user=user)
+
+        # Building the objects
+        access_obj = JWTModelFactory.build(
+            user=user, jti=access["payload"]["jti"], token=access["token"]
+        )
+        refresh_obj = JWTModelFactory.build(
+            user=user, jti=refresh["payload"]["jti"], token=refresh["token"]
+        )
+
+        # Mocking the methods
+        get_user: Mock = user_repository.get_user
+        get_tokens_user: Mock = jwt_repository.get_tokens_user
+        add_to_blacklist: Mock = jwt_repository.add_to_blacklist
+
+        # Setting the return values
+        get_user.return_value = user
+        get_tokens_user.return_value = [refresh_obj, access_obj]
+        add_to_blacklist.side_effect = DatabaseConnectionError
+
+        with pytest.raises(DatabaseConnectionError):
+            self.application_class(
+                user_repository=user_repository,
+                jwt_repository=jwt_repository,
+                jwt_class=jwt_class,
+            ).refresh_tokens(access_data=access, refresh_data=refresh)
+
+        get_user.assert_called_once_with(id=user.id)
+        get_tokens_user.assert_called_once_with(user=user)
+        add_to_blacklist.assert_called_once_with(token=refresh_obj)

--- a/src/tests/users/applications/test_register.py
+++ b/src/tests/users/applications/test_register.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock
 
 from apps.users.applications import Registration
 from apps.exceptions import DatabaseConnectionError
-from tests.users.factory import UserFactory
+from tests.users.factory import UserModelFactory
 
 
 class TestApplication:
@@ -29,7 +29,7 @@ class TestApplication:
     )
     def test_registration(self, user_repository: Mock, data) -> None:
 
-        user = UserFactory.build(**data)
+        user = UserModelFactory.build(**data)
 
         # Mocking the methods
         insert: Mock = user_repository.insert

--- a/src/tests/users/serializers/test_refresh_tokens.py
+++ b/src/tests/users/serializers/test_refresh_tokens.py
@@ -1,0 +1,83 @@
+import pytest
+
+from apps.users.infrastructure.serializers import RefreshTokenSerializer
+from tests.users.factory import JWTFactory
+
+
+class TestSerializer:
+    """
+    A class to test the RefreshTokenSerializer.
+
+    This class contains tests to validate the RefreshTokenSerializer. It tests
+    various scenarios such as valid and invalid data.
+    """
+
+    serializer_class = RefreshTokenSerializer
+
+    @pytest.mark.parametrize(
+        "access, refresh",
+        [(JWTFactory.access_exp(), JWTFactory.refresh())],
+        ids=["Valid data"],
+    )
+    def test_serializer_valid(self, access, refresh) -> None:
+
+        serializer = self.serializer_class(
+            data={"access": access["token"], "refresh": refresh["token"]}
+        )
+
+        assert serializer.is_valid()
+        assert serializer.initial_data["refresh"] == refresh["token"]
+        assert serializer.initial_data["access"] == access["token"]
+        assert (
+            serializer.validated_data["refresh"]["token"] == refresh["token"]
+        )
+        assert (
+            serializer.validated_data["refresh"]["payload"]
+            == refresh["payload"]
+        )
+        assert serializer.validated_data["access"]["token"] == access["token"]
+        assert (
+            serializer.validated_data["access"]["payload"] == access["payload"]
+        )
+
+    @pytest.mark.parametrize(
+        "access, refresh, error_message",
+        [
+            (
+                JWTFactory.access_invalid(),
+                JWTFactory.refresh(),
+                "Token is invalid.",
+            ),
+            (
+                JWTFactory.access_exp(),
+                JWTFactory.refresh_invalid(),
+                "Token is invalid.",
+            ),
+            (
+                JWTFactory.access_exp(),
+                JWTFactory.refresh_exp(),
+                "Token is expired.",
+            ),
+            (
+                JWTFactory.access(),
+                JWTFactory.refresh(),
+                "Token is not expired.",
+            ),
+        ],
+        ids=[
+            "access token invalid",
+            "refresh token invalid",
+            "refresh token expired",
+            "access token not expired",
+        ],
+    )
+    def test_serializer_invalid(self, access, refresh, error_message) -> None:
+
+        serializer = self.serializer_class(
+            data={"access": access["token"], "refresh": refresh["token"]}
+        )
+
+        assert not serializer.is_valid()
+        assert serializer.validated_data == {}
+        for _, value in serializer.errors.items():
+            assert value[0] == error_message

--- a/src/tests/users/serializers/test_register.py
+++ b/src/tests/users/serializers/test_register.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock, patch
 
 from apps.users.infrastructure.serializers import RegisterSerializer
 from apps.exceptions import UserNotFoundError
-from tests.users.factory import UserFactory
+from tests.users.factory import UserModelFactory
 
 
 class TestSerializer:
@@ -151,7 +151,7 @@ class TestSerializer:
         self, repository: Mock, data: Dict[str, str]
     ) -> None:
 
-        user = UserFactory.build(email=data["email"])
+        user = UserModelFactory.build(email=data["email"])
 
         # Mocking the methods
         get_user: Mock = repository.get_user

--- a/src/tests/users/views/test_authentication.py
+++ b/src/tests/users/views/test_authentication.py
@@ -70,8 +70,8 @@ class TestAPIView:
             (
                 {"email": "user@example.com", "password": "Aaa123456789"},
                 401,
-                "user_inactive",
-                "Cuenta inactiva.",
+                "authentication_failed",
+                "Cuenta del usuario inactiva.",
                 True,
                 False,
             ),

--- a/src/tests/users/views/test_refresh_tokens.py
+++ b/src/tests/users/views/test_refresh_tokens.py
@@ -1,0 +1,177 @@
+from rest_framework_simplejwt.utils import aware_utcnow
+from django.test import Client
+from django.urls import reverse
+import pytest
+
+from typing import Tuple
+from unittest.mock import Mock, patch
+
+from apps.users.domain.constants import (
+    ACCESS_TOKEN_LIFETIME,
+    REFRESH_TOKEN_LIFETIME,
+)
+from apps.users.models import JWT, JWTBlacklisted
+from apps.exceptions import DatabaseConnectionError
+from tests.users.factory import JWTFactory, UserModelFactory, JWTModelFactory
+
+
+@pytest.fixture
+def setUp() -> Tuple[Client, str]:
+    return Client(), reverse(viewname="refresh_token")
+
+
+@pytest.mark.django_db
+class TestAPIView:
+    """
+    This class groups all the test cases for the `TokenRefreshAPIView` API view. This
+    view is responsible for refreshing the access token of a user in the real estate
+    management system.
+    """
+
+    def test_request_valid(self, setUp: Tuple[Client, str]) -> None:
+
+        assert JWTBlacklisted.objects.count() == 0
+
+        user = UserModelFactory.create(is_active=True)
+        refresh = JWTFactory.refresh(user=user)
+        access = JWTFactory.access_exp(user=user)
+
+        client, path = setUp
+
+        JWTModelFactory.create(
+            user=user,
+            jti=access["payload"]["jti"],
+            token=access["token"],
+            expires_at=aware_utcnow() + ACCESS_TOKEN_LIFETIME,
+        )
+        JWTModelFactory.create(
+            user=user,
+            jti=refresh["payload"]["jti"],
+            token=refresh["token"],
+            expires_at=aware_utcnow() + REFRESH_TOKEN_LIFETIME,
+        )
+
+        response = client.post(
+            path=path,
+            data={"refresh": refresh["token"], "access": access["token"]},
+        )
+
+        assert response.status_code == 200
+        assert (
+            JWTBlacklisted.objects.select_related("token")
+            .filter(token__jti=access["payload"]["jti"])
+            .exists()
+        )
+        assert (
+            JWTBlacklisted.objects.select_related("token")
+            .filter(token__jti=refresh["payload"]["jti"])
+            .exists()
+        )
+        assert JWT.objects.filter(token=response.data["access"]).exists()
+        assert JWT.objects.filter(token=response.data["refresh"]).exists()
+
+    def test_request_invalid(self, setUp: Tuple[Client, str]) -> None:
+
+        user = UserModelFactory.create(is_active=True)
+        refresh = JWTFactory.refresh(user=user)
+        access = JWTFactory.access(user=user)
+
+        client, path = setUp
+
+        response = client.post(
+            path=path,
+            data={"refresh": refresh["token"], "access": access["token"]},
+        )
+
+        assert response.status_code == 401
+        assert JWTBlacklisted.objects.count() == 0
+        assert JWT.objects.count() == 0
+        assert response.data["code"] == "jwt_error"
+        assert (
+            str(response.data["detail"]["access"][0])
+            == "Token is not expired."
+        )
+
+    def test_user_not_found(self, setUp: Tuple[Client, str]) -> None:
+
+        user = UserModelFactory.build(is_active=True)
+        refresh = JWTFactory.refresh(user=user)
+        access = JWTFactory.access_exp(user=user)
+
+        client, path = setUp
+
+        response = client.post(
+            path=path,
+            data={"refresh": refresh["token"], "access": access["token"]},
+        )
+
+        assert response.status_code == 404
+        assert JWTBlacklisted.objects.count() == 0
+        assert JWT.objects.count() == 0
+        assert response.data["code"] == "user_not_found"
+        assert response.data["detail"] == f"User {user.id} not found."
+
+    @patch("apps.users.infrastructure.views.refresh_token.UserRepository")
+    def test_db_error(
+        self, repository: Mock, setUp: Tuple[Client, str]
+    ) -> None:
+
+        # Mocking the methods
+        get_user: Mock = repository.get_user
+
+        # Setting the return values
+        get_user.side_effect = DatabaseConnectionError
+
+        user = UserModelFactory.create(is_active=True)
+        refresh = JWTFactory.refresh(user=user)
+        access = JWTFactory.access_exp(user=user)
+
+        client, path = setUp
+
+        response = client.post(
+            path=path,
+            data={"refresh": refresh["token"], "access": access["token"]},
+        )
+
+        assert response.status_code == 500
+        assert response.data["code"] == "database_connection_error"
+        assert (
+            response.data["detail"]
+            == "Unable to establish a connection with the database. Please try again later."
+        )
+
+    def test_jwt_not_matching(self, setUp: Tuple[Client, str]) -> None:
+
+        user = UserModelFactory.create(is_active=True)
+        refresh = JWTFactory.refresh(user=user)
+        access = JWTFactory.access_exp(user=user)
+
+        # Building the objects
+        JWTModelFactory.create(
+            user=user,
+            jti="123",
+            token="access",
+            expires_at=aware_utcnow() + ACCESS_TOKEN_LIFETIME,
+        )
+        JWTModelFactory.create(
+            user=user,
+            jti="456",
+            token="refresh",
+            expires_at=aware_utcnow() + REFRESH_TOKEN_LIFETIME,
+        )
+
+        client, path = setUp
+
+        response = client.post(
+            path=path,
+            data={"refresh": refresh["token"], "access": access["token"]},
+        )
+
+        assert response.status_code == 401
+        assert response.data["code"] == "token_error"
+        assert (
+            response.data["detail"]["message"]
+            == "The token does not match the user's last tokens."
+        )
+        assert response.data["detail"].get("token_type", False)
+        assert response.data["detail"].get("token", False)

--- a/src/tests/users/views/test_register.py
+++ b/src/tests/users/views/test_register.py
@@ -5,7 +5,7 @@ import pytest
 from typing import Tuple
 
 from apps.users.models import User
-from tests.users.factory import UserFactory
+from tests.users.factory import UserModelFactory
 
 
 @pytest.fixture
@@ -84,7 +84,7 @@ class TestAPIView:
 
         client, path = setUp
 
-        UserFactory.create(email=data["email"], password=data["password"])
+        UserModelFactory.create(email=data["email"], password=data["password"])
 
         response = client.post(path=path, data=data)
 


### PR DESCRIPTION
## Descripción de los Cambios

Esta solicitud introduce un nuevo punto final de actualización de JWT (`POST /api/v1/jwt/refresh/`) basandose en el principio del punto final de la aplicación [rest_framework_simplejwt](https://django-rest-framework-simplejwt.readthedocs.io/en/latest/). El punto final acepta los  tokens de acceso y actualización como parámetros de entrada. Valida estos tokens y, si son válidos, genera nuevos tokens para el usuario.

Se verifican las siguientes condiciones antes de generar nuevos tokens:

1. El token de acceso debe estar caducado pero aún ser válido.
2. El token de actualización debe estar activo y ser válido.
3. Si se cumplen estas condiciones, se generan nuevos tokens para el usuario. Los tokens antiguos se agregan a la lista negra (modelo `JWTBlacklisted`) y los tokens nuevos se agregan a la lista de tokens pendientes (modelo `JWT`).
4. Cualquier error que pueda ocurrir durante el proceso de actualización del token, como que la base de datos esté fuera de servicio, se maneja adecuadamente.

## Notas Adicionales

- Se han implementado pruebas para garantizar la solidez del punto final modificado. Estas pruebas cubren todos los criterios de aceptación y casos extremos, como que la base de datos esté fuera de servicio.
- El nuevo punto final se ha documentado en la documentación de la API.

## Imagenes

![Captura de pantalla -2024-03-24 10-39-04](https://github.com/CodingFlashOR/api-inmobiliaria/assets/120736166/dfef0220-2d32-4237-ac4d-678db1240fe4)
![Captura de pantalla -2024-03-24 10-39-20](https://github.com/CodingFlashOR/api-inmobiliaria/assets/120736166/8c132a26-161c-4bc4-9e6f-840e64a6e60e)
![Captura de pantalla -2024-03-24 10-35-29](https://github.com/CodingFlashOR/api-inmobiliaria/assets/120736166/1e0cf720-a523-4b6b-8596-02aac567d0ed)


closes #3